### PR TITLE
Fixup GH URL and scm tag placeholder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,7 @@
   <packaging>hpi</packaging>
 
   <name>Xygeni Sensor</name>
-  <description>Xygeni Sensor enables you to integrate a Xygeni Scanner execution step into a pipeline,
-    display execution results in the build view, and
-    collect information from the Jenkins system to identify unusual activity.</description>
-  <url>https://github.com/jenkinsci/xygeni-plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>
@@ -29,7 +26,7 @@
   <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
     <connection>scm:git:https://github.com/${gitHubRepo}</connection>
     <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
-    <tag>xygeni-sensor-1.2</tag>
+    <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
 


### PR DESCRIPTION
The change proposed fixes the wrong scm tag placeholder and wrong GitHub URL, causing an empty page on the plugin portal:
![Screenshot 2024-03-30 at 09 36 48](https://github.com/jenkinsci/xygeni-sensor-plugin/assets/13383509/0430a49a-6b31-40b2-bb33-96d5d7fecbba)